### PR TITLE
[feat] 스터디 생성 로직 구현

### DIFF
--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,0 +1,3 @@
+
+
+Co-authored-by: choi-jjunho <junho5336@gmail.com>

--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,3 +1,0 @@
-
-
-Co-authored-by: choi-jjunho <junho5336@gmail.com>

--- a/src/main/java/cholog/supp/api/member/service/MemberService.java
+++ b/src/main/java/cholog/supp/api/member/service/MemberService.java
@@ -9,8 +9,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class MemberService {
 

--- a/src/main/java/cholog/supp/api/study/controller/StudyGroupController.java
+++ b/src/main/java/cholog/supp/api/study/controller/StudyGroupController.java
@@ -3,6 +3,7 @@ package cholog.supp.api.study.controller;
 import cholog.supp.api.common.APISuccessResponse;
 import cholog.supp.api.study.dto.CreateStudyGroupRequest;
 import cholog.supp.api.study.service.StudyGroupService;
+import cholog.supp.db.member.MemberCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,7 +21,6 @@ public class StudyGroupController {
     @PostMapping("/group")
     public ResponseEntity<APISuccessResponse<Void>> createGroup(
         @RequestBody CreateStudyGroupRequest request) {
-//        studyGroupService
-        return null;
+        studyGroupService
     }
 }

--- a/src/main/java/cholog/supp/api/study/controller/StudyGroupController.java
+++ b/src/main/java/cholog/supp/api/study/controller/StudyGroupController.java
@@ -1,0 +1,26 @@
+package cholog.supp.api.study.controller;
+
+import cholog.supp.api.common.APISuccessResponse;
+import cholog.supp.api.study.dto.CreateStudyGroupRequest;
+import cholog.supp.api.study.service.StudyGroupService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class StudyGroupController {
+
+    private final StudyGroupService studyGroupService;
+
+    @PostMapping("/group")
+    public ResponseEntity<APISuccessResponse<Void>> createGroup(
+        @RequestBody CreateStudyGroupRequest request) {
+//        studyGroupService
+        return null;
+    }
+}

--- a/src/main/java/cholog/supp/api/study/controller/StudyGroupController.java
+++ b/src/main/java/cholog/supp/api/study/controller/StudyGroupController.java
@@ -3,6 +3,8 @@ package cholog.supp.api.study.controller;
 import cholog.supp.api.common.APISuccessResponse;
 import cholog.supp.api.study.dto.CreateStudyGroupRequest;
 import cholog.supp.api.study.service.StudyGroupService;
+import cholog.supp.common.auth.Auth;
+import cholog.supp.db.member.Member;
 import cholog.supp.db.member.MemberCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,8 +21,9 @@ public class StudyGroupController {
     private final StudyGroupService studyGroupService;
 
     @PostMapping("/group")
-    public ResponseEntity<APISuccessResponse<Void>> createGroup(
-        @RequestBody CreateStudyGroupRequest request) {
-        studyGroupService
+    public ResponseEntity createGroup(
+        @RequestBody CreateStudyGroupRequest request, @Auth Member member) {
+        studyGroupService.createStudyGroup(request, member);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/cholog/supp/api/study/dto/CreateStudyGroupRequest.java
+++ b/src/main/java/cholog/supp/api/study/dto/CreateStudyGroupRequest.java
@@ -1,0 +1,5 @@
+package cholog.supp.api.study.dto;
+
+public record CreateStudyGroupRequest(String studyName, String organization) {
+
+}

--- a/src/main/java/cholog/supp/api/study/service/StudyGroupService.java
+++ b/src/main/java/cholog/supp/api/study/service/StudyGroupService.java
@@ -25,7 +25,6 @@ public class StudyGroupService {
     public void createStudyGroup(CreateStudyGroupRequest request, Member member) {
         StudyGroup studyGroup = studyGroupRepository.save(
             new StudyGroup(request.studyName(), request.organization()));
-        //스터디 생성 링크를 주고 만들었을 때 비로소 그 스터디에서만 노드가 된다.
         MemberCategory memberCategory = memberCategoryRepository.save(
             new MemberCategory(member, MemberType.NODE));
         memberStudyMapRepository.save(new MemberStudyMap(member, memberCategory, studyGroup));

--- a/src/main/java/cholog/supp/api/study/service/StudyGroupService.java
+++ b/src/main/java/cholog/supp/api/study/service/StudyGroupService.java
@@ -1,6 +1,12 @@
 package cholog.supp.api.study.service;
 
 import cholog.supp.api.study.dto.CreateStudyGroupRequest;
+import cholog.supp.db.member.Member;
+import cholog.supp.db.member.MemberCategory;
+import cholog.supp.db.member.MemberCategoryRepository;
+import cholog.supp.db.member.MemberStudyMap;
+import cholog.supp.db.member.MemberStudyMapRepository;
+import cholog.supp.db.member.MemberType;
 import cholog.supp.db.study.StudyGroup;
 import cholog.supp.db.study.StudyGroupRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +19,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudyGroupService {
 
     private final StudyGroupRepository studyGroupRepository;
+    private final MemberCategoryRepository memberCategoryRepository;
+    private final MemberStudyMapRepository memberStudyMapRepository;
 
-    public void createStudyGroup(CreateStudyGroupRequest request) {
-        studyGroupRepository.save(new StudyGroup(request.studyName(), request.organization()));
+    public void createStudyGroup(CreateStudyGroupRequest request, Member member) {
+        StudyGroup studyGroup = studyGroupRepository.save(
+            new StudyGroup(request.studyName(), request.organization()));
+        //스터디 생성 링크를 주고 만들었을 때 비로소 그 스터디에서만 노드가 된다.
+        MemberCategory memberCategory = memberCategoryRepository.save(
+            new MemberCategory(member, MemberType.NODE));
+        memberStudyMapRepository.save(new MemberStudyMap(member, memberCategory, studyGroup));
     }
 }

--- a/src/main/java/cholog/supp/api/study/service/StudyGroupService.java
+++ b/src/main/java/cholog/supp/api/study/service/StudyGroupService.java
@@ -1,0 +1,20 @@
+package cholog.supp.api.study.service;
+
+import cholog.supp.api.study.dto.CreateStudyGroupRequest;
+import cholog.supp.db.study.StudyGroup;
+import cholog.supp.db.study.StudyGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StudyGroupService {
+
+    private final StudyGroupRepository studyGroupRepository;
+
+    public void createStudyGroup(CreateStudyGroupRequest request) {
+        studyGroupRepository.save(new StudyGroup(request.studyName(), request.organization()));
+    }
+}

--- a/src/main/java/cholog/supp/db/member/MemberCategory.java
+++ b/src/main/java/cholog/supp/db/member/MemberCategory.java
@@ -36,4 +36,8 @@ public class MemberCategory {
     @Column(name = "member_type", nullable = false)
     private MemberType memberType;
 
+    public MemberCategory(Member member, MemberType memberType) {
+        this.member = member;
+        this.memberType = memberType;
+    }
 }

--- a/src/main/java/cholog/supp/db/member/MemberCategory.java
+++ b/src/main/java/cholog/supp/db/member/MemberCategory.java
@@ -2,6 +2,7 @@ package cholog.supp.db.member;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -32,7 +33,7 @@ public class MemberCategory {
     private Member member;
 
     @NotNull
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     @Column(name = "member_type", nullable = false)
     private MemberType memberType;
 

--- a/src/main/java/cholog/supp/db/member/MemberCategory.java
+++ b/src/main/java/cholog/supp/db/member/MemberCategory.java
@@ -1,0 +1,39 @@
+package cholog.supp.db.member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "MEMBER_CATEGORY")
+@NoArgsConstructor
+public class MemberCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_category_id", nullable = false)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @NotNull
+    @Enumerated
+    @Column(name = "member_type", nullable = false)
+    private MemberType memberType;
+
+}

--- a/src/main/java/cholog/supp/db/member/MemberCategoryRepository.java
+++ b/src/main/java/cholog/supp/db/member/MemberCategoryRepository.java
@@ -1,0 +1,7 @@
+package cholog.supp.db.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberCategoryRepository extends JpaRepository<MemberCategory, Long> {
+
+}

--- a/src/main/java/cholog/supp/db/member/MemberStudyMap.java
+++ b/src/main/java/cholog/supp/db/member/MemberStudyMap.java
@@ -38,6 +38,11 @@ public class MemberStudyMap {
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "study_id", nullable = false)
-    private StudyGroup study;
+    private StudyGroup studyGroup;
 
+    public MemberStudyMap(Member member, MemberCategory memberCategory, StudyGroup studyGroup) {
+        this.member = member;
+        this.memberCategory = memberCategory;
+        this.studyGroup = studyGroup;
+    }
 }

--- a/src/main/java/cholog/supp/db/member/MemberStudyMap.java
+++ b/src/main/java/cholog/supp/db/member/MemberStudyMap.java
@@ -1,0 +1,43 @@
+package cholog.supp.db.member;
+
+import cholog.supp.db.study.StudyGroup;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "MEMBER_STUDY_MAP")
+@NoArgsConstructor
+public class MemberStudyMap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_study_id", nullable = false)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_category_id")
+    private MemberCategory memberCategory;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "study_id", nullable = false)
+    private StudyGroup study;
+
+}

--- a/src/main/java/cholog/supp/db/member/MemberStudyMapRepository.java
+++ b/src/main/java/cholog/supp/db/member/MemberStudyMapRepository.java
@@ -1,0 +1,7 @@
+package cholog.supp.db.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberStudyMapRepository extends JpaRepository<MemberStudyMap, Long> {
+
+}

--- a/src/main/java/cholog/supp/db/member/MemberType.java
+++ b/src/main/java/cholog/supp/db/member/MemberType.java
@@ -1,0 +1,8 @@
+package cholog.supp.db.member;
+
+public enum MemberType {
+    NODE,
+    LEAF,
+    FRUIT,
+    ;
+}

--- a/src/main/java/cholog/supp/db/study/StudyGroup.java
+++ b/src/main/java/cholog/supp/db/study/StudyGroup.java
@@ -1,0 +1,38 @@
+package cholog.supp.db.study;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "STUDY")
+@NoArgsConstructor
+public class StudyGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_id", nullable = false)
+    private Long id;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "study_name", nullable = false)
+    private String name;
+
+    @Size(max = 255)
+    @Column(name = "organization")
+    private String organization;
+
+    public StudyGroup(String name, String organization) {
+        this.name = name;
+        this.organization = organization;
+    }
+}

--- a/src/main/java/cholog/supp/db/study/StudyGroupRepository.java
+++ b/src/main/java/cholog/supp/db/study/StudyGroupRepository.java
@@ -1,0 +1,7 @@
+package cholog.supp.db.study;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
+
+}


### PR DESCRIPTION
중간테이블과 함께 저장해주는 로직 포함.
스터디 생성 링크를 통해 페이지에 접근 -> 스터디명/학교 쓴 후 요청 보냄 -> 해당 스터디에 노드 직책을 가지고 저장 -> 직책과 멤버랑 스터디를 엮어주는 중간 테이블에 저장