### PR TITLE
refactor: @Transactional(readOnly=true) 중첩사용

### DIFF
--- a/src/main/java/cholog/supp/api/comment/dto/request/ModifyCommentRequest.java
+++ b/src/main/java/cholog/supp/api/comment/dto/request/ModifyCommentRequest.java
@@ -2,6 +2,7 @@ package cholog.supp.api.comment.dto.request;
 
 public record ModifyCommentRequest(
     Long commentId,
-    String content) {
+    String content
+) {
 
 }

--- a/src/main/java/cholog/supp/api/member/dto/request/SignInMember.java
+++ b/src/main/java/cholog/supp/api/member/dto/request/SignInMember.java
@@ -1,5 +1,8 @@
 package cholog.supp.api.member.dto.request;
 
-public record SignInMember(String email, String password) {
+public record SignInMember(
+    String email,
+    String password
+) {
 
 }

--- a/src/main/java/cholog/supp/api/member/dto/request/SignUpMember.java
+++ b/src/main/java/cholog/supp/api/member/dto/request/SignUpMember.java
@@ -1,5 +1,8 @@
 package cholog.supp.api.member.dto.request;
 
-public record SignUpMember(String email, String password) {
+public record SignUpMember(
+    String email,
+    String password
+) {
 
 }

--- a/src/main/java/cholog/supp/api/post/dto/ModifyPost.java
+++ b/src/main/java/cholog/supp/api/post/dto/ModifyPost.java
@@ -2,6 +2,7 @@ package cholog.supp.api.post.dto;
 
 public record ModifyPost(
     String title,
-    String description) {
+    String description
+) {
 
 }

--- a/src/main/java/cholog/supp/api/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/cholog/supp/api/post/dto/request/CreatePostRequest.java
@@ -3,6 +3,7 @@ package cholog.supp.api.post.dto.request;
 public record CreatePostRequest(
     String title,
     String description,
-    Long studyId) {
+    Long studyId
+) {
 
 }

--- a/src/main/java/cholog/supp/api/post/dto/request/PostsRequest.java
+++ b/src/main/java/cholog/supp/api/post/dto/request/PostsRequest.java
@@ -1,7 +1,0 @@
-package cholog.supp.api.post.dto.request;
-
-public record PostsRequest(
-    Long studyId
-) {
-
-}

--- a/src/main/java/cholog/supp/api/post/service/PostService.java
+++ b/src/main/java/cholog/supp/api/post/service/PostService.java
@@ -77,7 +77,6 @@ public class PostService {
         return new EachPostResponse(eachPost, comments);
     }
 
-    @Transactional(readOnly = true)
     public List<EachComment> getCommentList(Long studyId, List<Comment> comments, Member member) {
         return comments.stream().map(comment -> {
             Member nowCommentMember = comment.getMember();
@@ -90,6 +89,4 @@ public class PostService {
             return new EachComment(comment, memberType, isAuthor);
         }).toList();
     }
-
-
 }

--- a/src/main/java/cholog/supp/api/studygroup/dto/request/CreateStudyGroupRequest.java
+++ b/src/main/java/cholog/supp/api/studygroup/dto/request/CreateStudyGroupRequest.java
@@ -2,6 +2,7 @@ package cholog.supp.api.studygroup.dto.request;
 
 public record CreateStudyGroupRequest(
     String studyName,
-    String organization) {
+    String organization
+) {
 
 }


### PR DESCRIPTION
1. saveAndFlush 고려를 해보았습니다.
* 그런데 필요성을 잘 모르겠어요. 현재 `@Transactional`이 Service 클래스 상위에 선언이 되어있고, 읽기전용으로 쓰는 것 에만 `readOnly=true`가 되어있는데요, 회원가입 시에 save후 바로 메서드가 끝나기때문에 DB에 무리없이 반영될 것 같습니다. 그리고 중복 이메일에 대한 건은 save전에 이메일 검증을 한번 더 해주기 때문에(이메일 중복 검증 버튼 이외에 한번 더 회원가입 버튼을 눌렀을 때 중복 검증이 되는 것) 과연 중복때문에 문제가 생길지 의문이었어요! 그래서 우선은 save로 남겨두었습니다

2. `@Transactional(readOnly=true)`를 PostService의 getCommentList 메서드에서 빼줬어요!! getCommentList 메서드는 getEachPost에서 호출되는것으로만 사용되는데용 getEachPost에 `@Transactional(readOnly=true)`가 되어있기 때문에 하위에도 적용이 될 것으로 생각했어요 [참고](https://rudaks.tistory.com/entry/Transactional의-readonly-옵션의-중첩-사용)

3. 하나 논의할 사항을 미리 말해 두자면 dto에 studyId 와 studyGroupId가 섞여서 쓰이는데요, 이걸 studyGroupId으로 통일하는게 좋을 것 같다는 의견이 나왔어요. 프론트에 피바람이 불 것 같아서 ... 멋대로 해두기보다 우선 함께 논의 후 진행하겠습니다..^^

4. url의 groups를 studygroups라고 하기에는 가독성이 너무 떨어지는 것 같아서 이거는 groups로 남겨두는게 어떤가요?